### PR TITLE
If a dialog is close by clicking x, nothing will happen

### DIFF
--- a/PurpleExplorer/ViewModels/AddMessageWindowViewModal.cs
+++ b/PurpleExplorer/ViewModels/AddMessageWindowViewModal.cs
@@ -1,7 +1,8 @@
 namespace PurpleExplorer.ViewModels
 {
-    public class AddMessageWindowViewModal : ViewModelBase
+    public class AddMessageWindowViewModal : DialogViewModelBase
     {
         public string Message { get; set; }
+        public AddMessageWindowViewModal() : base() { }
     }
 }  

--- a/PurpleExplorer/ViewModels/ConnectionStringWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/ConnectionStringWindowViewModel.cs
@@ -1,7 +1,9 @@
 ﻿namespace PurpleExplorer.ViewModels
 {
-    public class ConnectionStringWindowViewModel : ViewModelBase
+    public class ConnectionStringWindowViewModel : DialogViewModelBase
     {
         public string ConnectionString { get; set; }
+
+        public ConnectionStringWindowViewModel() : base() { }
     }
 }

--- a/PurpleExplorer/ViewModels/DialogViewModelBase.cs
+++ b/PurpleExplorer/ViewModels/DialogViewModelBase.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PurpleExplorer.ViewModels
+{
+    public class DialogViewModelBase : ViewModelBase 
+    {
+        public bool Cancel { get; set; }
+        
+        public DialogViewModelBase()
+        {
+            this.Cancel = true;
+        }
+    }
+}

--- a/PurpleExplorer/ViewModels/MainWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/MainWindowViewModel.cs
@@ -60,30 +60,33 @@ namespace PurpleExplorer.ViewModels
             var returnedViewModel =
                 await ModalWindowHelper.ShowModalWindow<ConnectionStringWindow, ConnectionStringWindowViewModel>(
                     viewModel);
-            _connectionString = returnedViewModel.ConnectionString.Trim();
+            _connectionString = returnedViewModel.ConnectionString?.Trim();
 
-            if (string.IsNullOrEmpty(_connectionString))
+            if (!returnedViewModel.Cancel)
             {
-                return;
-            }
-
-            try
-            {
-                var namespaceInfo = await _serviceBusHelper.GetNamespaceInfo(_connectionString);
-                var topics = await _serviceBusHelper.GetTopics(_connectionString);
-
-                var newResource = new ServiceBusResource
+                if (string.IsNullOrEmpty(_connectionString))
                 {
-                    Name = namespaceInfo.Name,
-                    ConnectionString = _connectionString,
-                    Topics = new ObservableCollection<ServiceBusTopic>(topics)
-                };
+                    return;
+                }
 
-                ConnectedServiceBuses.Add(newResource);
-            }
-            catch (ArgumentException)
-            {
-                await MessageBoxHelper.ShowError("The connection string is invalid.");
+                try
+                {
+                    var namespaceInfo = await _serviceBusHelper.GetNamespaceInfo(_connectionString);
+                    var topics = await _serviceBusHelper.GetTopics(_connectionString);
+
+                    var newResource = new ServiceBusResource
+                    {
+                        Name = namespaceInfo.Name,
+                        ConnectionString = _connectionString,
+                        Topics = new ObservableCollection<ServiceBusTopic>(topics)
+                    };
+
+                    ConnectedServiceBuses.Add(newResource);
+                }
+                catch (ArgumentException)
+                {
+                    await MessageBoxHelper.ShowError("The connection string is invalid.");
+                }
             }
         }
 
@@ -123,11 +126,18 @@ namespace PurpleExplorer.ViewModels
             if (CurrentSubscription != null || (CurrentTopic != null && CurrentTopic.Subscriptions.Count > 0))
             {
                 var viewModal = new AddMessageWindowViewModal();
+
                 var topicName = CurrentSubscription == null ? CurrentTopic.Name : CurrentSubscription.Topic.Name;
                 var returnedViewModal =
                     await ModalWindowHelper.ShowModalWindow<AddMessageWindow, AddMessageWindowViewModal>(viewModal);
-                var message = returnedViewModal.Message.Trim();
-                await _serviceBusHelper.SendTopicMessage(_connectionString, topicName, message);
+
+                if (!returnedViewModal.Cancel)
+                {
+                    var message = returnedViewModal.Message;
+
+                    if (!string.IsNullOrEmpty(message))
+                        await _serviceBusHelper.SendTopicMessage(_connectionString, topicName, message.Trim());
+                }            
             }
 
             if (CurrentTopic != null && CurrentTopic.Subscriptions.Count == 0)

--- a/PurpleExplorer/Views/AddMessageWindow.xaml
+++ b/PurpleExplorer/Views/AddMessageWindow.xaml
@@ -6,10 +6,11 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="PurpleExplorer.Views.AddMessageWindow"
         Title="AvaloniaAppTemplate" Width="700" Height="100">
+    
     <Design.DataContext>
         <viewModels:AddMessageWindowViewModal />
     </Design.DataContext>
-    
+
     <StackPanel>
         <TextBox Width="600" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Text="{Binding Path=Message, Mode=TwoWay}"></TextBox>
         <Button Width="200" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnAddClick">Add Message</Button>

--- a/PurpleExplorer/Views/AddMessageWindow.xaml.cs
+++ b/PurpleExplorer/Views/AddMessageWindow.xaml.cs
@@ -28,7 +28,10 @@ namespace PurpleExplorer.Views
                 await MessageBoxHelper.ShowError(MessageBox.Avalonia.Enums.ButtonEnum.OkCancel, "Error",
                     "Please enter a message to be sent");
             else
+            {
+                dataContext.Cancel = false;
                 Close();
+            }
         }
     }
 }

--- a/PurpleExplorer/Views/ConnectionStringWindow.xaml.cs
+++ b/PurpleExplorer/Views/ConnectionStringWindow.xaml.cs
@@ -23,7 +23,10 @@ namespace PurpleExplorer.Views
             if (string.IsNullOrEmpty(dataContext.ConnectionString))
                 await MessageBoxHelper.ShowError(MessageBox.Avalonia.Enums.ButtonEnum.OkCancel, "Error", "Please enter a service bus connection string.");
             else
+            {
+                dataContext.Cancel = false;
                 this.Close();
+            }
         }
     }
 }


### PR DESCRIPTION
I have created a base class for Dialog view models.  It has a property "Cancel" which is used to detect whether the dialog was closed by submitting, or by closing the window "x" button.  If user closes the window without submitting, nothing should happen.

All future dialogs should use this as the base class of the ViewModel class.