### PR TITLE
Fix Treeview (MessageCount, DlqCount) not updating

### DIFF
--- a/PurpleExplorer/Helpers/IServiceBusHelper.cs
+++ b/PurpleExplorer/Helpers/IServiceBusHelper.cs
@@ -14,6 +14,7 @@ namespace PurpleExplorer.Helpers
         public Task<IList<Models.Message>> GetMessagesBySubscription(string connectionString, string topicName, string subscriptionName);
         public Task SendTopicMessage(string connectionString, string topicPath, string message);
         public void DeleteMessage(string connectionString, string topicPath, string subscriptionPath, Message message, bool isDlq);
-
+        public Task<SubscriptionRuntimeInfo> GetSubscriptionRuntimeInfo(string connectionString, string topicPath,
+            string subscriptionName);
     }
 }

--- a/PurpleExplorer/Models/ServiceBusSubscription.cs
+++ b/PurpleExplorer/Models/ServiceBusSubscription.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using Microsoft.Azure.ServiceBus.Management;
 
 namespace PurpleExplorer.Models
 {
@@ -11,10 +12,19 @@ namespace PurpleExplorer.Models
         public ObservableCollection<Message> Messages { get; }
         public ObservableCollection<Message> DlqMessages { get; }
 
-        public ServiceBusSubscription()
+        public ServiceBusSubscription(SubscriptionRuntimeInfo subscription)
         {
             Messages = new ObservableCollection<Message>();
             DlqMessages = new ObservableCollection<Message>();
+            Name = subscription.SubscriptionName;
+            MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
+            DLQCount = subscription.MessageCountDetails.DeadLetterMessageCount;
+        }
+
+        public void UpdateMessageDlqCount(SubscriptionRuntimeInfo subscription)
+        {
+            MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
+            DLQCount = subscription.MessageCountDetails.DeadLetterMessageCount;
         }
     }
 }

--- a/PurpleExplorer/Models/ServiceBusSubscription.cs
+++ b/PurpleExplorer/Models/ServiceBusSubscription.cs
@@ -1,13 +1,24 @@
 using System.Collections.ObjectModel;
 using Microsoft.Azure.ServiceBus.Management;
+using ReactiveUI;
 
 namespace PurpleExplorer.Models
 {
-    public class ServiceBusSubscription
+    public class ServiceBusSubscription: ReactiveObject
     {
         public string Name { get; set; }
-        public long MessageCount { get; set; }
-        public long DLQCount { get; set; }
+        private long _messageCount;
+        public long MessageCount
+        {
+            get => _messageCount;
+            set => this.RaiseAndSetIfChanged(ref _messageCount, value);
+        }
+        private long _dlqCount;
+        public long DlqCount
+        {
+            get => _dlqCount;
+            set => this.RaiseAndSetIfChanged(ref _dlqCount, value);
+        }
         public ServiceBusTopic Topic { get; set; }
         public ObservableCollection<Message> Messages { get; }
         public ObservableCollection<Message> DlqMessages { get; }
@@ -18,13 +29,13 @@ namespace PurpleExplorer.Models
             DlqMessages = new ObservableCollection<Message>();
             Name = subscription.SubscriptionName;
             MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
-            DLQCount = subscription.MessageCountDetails.DeadLetterMessageCount;
+            DlqCount = subscription.MessageCountDetails.DeadLetterMessageCount;
         }
 
         public void UpdateMessageDlqCount(SubscriptionRuntimeInfo subscription)
         {
             MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
-            DLQCount = subscription.MessageCountDetails.DeadLetterMessageCount;
+            DlqCount = subscription.MessageCountDetails.DeadLetterMessageCount;
         }
     }
 }

--- a/PurpleExplorer/Models/ServiceBusSubscription.cs
+++ b/PurpleExplorer/Models/ServiceBusSubscription.cs
@@ -28,14 +28,13 @@ namespace PurpleExplorer.Models
             Messages = new ObservableCollection<Message>();
             DlqMessages = new ObservableCollection<Message>();
             Name = subscription.SubscriptionName;
-            MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
-            DlqCount = subscription.MessageCountDetails.DeadLetterMessageCount;
+            UpdateMessageCountDetails(subscription.MessageCountDetails);
         }
 
-        public void UpdateMessageDlqCount(SubscriptionRuntimeInfo subscription)
+        public void UpdateMessageCountDetails(MessageCountDetails messageCountDetails)
         {
-            MessageCount = subscription.MessageCountDetails.ActiveMessageCount;
-            DlqCount = subscription.MessageCountDetails.DeadLetterMessageCount;
+            MessageCount = messageCountDetails.ActiveMessageCount;
+            DlqCount = messageCountDetails.DeadLetterMessageCount;
         }
     }
 }

--- a/PurpleExplorer/ViewModels/MainWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/MainWindowViewModel.cs
@@ -151,7 +151,7 @@ namespace PurpleExplorer.ViewModels
             else
             {
                 MessagesTabHeader = $"Messages ({CurrentSubscription.MessageCount})";
-                DlqTabHeader = $"Dead-letter ({CurrentSubscription.DLQCount})";
+                DlqTabHeader = $"Dead-letter ({CurrentSubscription.DlqCount})";
             }
         }
 

--- a/PurpleExplorer/ViewModels/MainWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/MainWindowViewModel.cs
@@ -137,7 +137,7 @@ namespace PurpleExplorer.ViewModels
             var subscriptionName = CurrentSubscription.Name;
             var runtimeInfo = await _serviceBusHelper.GetSubscriptionRuntimeInfo(connectionString, topicPath, subscriptionName);
             
-            CurrentSubscription.UpdateMessageDlqCount(runtimeInfo);
+            CurrentSubscription.UpdateMessageCountDetails(runtimeInfo.MessageCountDetails);
             SetTabHeaders();   
         }
 

--- a/PurpleExplorer/Views/MainWindow.xaml
+++ b/PurpleExplorer/Views/MainWindow.xaml
@@ -90,7 +90,7 @@
                                     <MultiBinding StringFormat="{}{0}({1},{2})">
                                         <Binding Path="Name" />
                                         <Binding Path="MessageCount" />
-                                        <Binding Path="DLQCount" />
+                                        <Binding Path="DlqCount" />
                                     </MultiBinding>
                                 </TextBlock.Text>
                             </TextBlock>


### PR DESCRIPTION
* `DlqCount` and `MessageCount` in `ServiceBusSubscription` will now raise a notification (for the UI) when its values has been updated
* `TabHeader` message counts are using the properties instead of the `List.Count` for consistency
* hitting the `Refresh` button will trigger getting updated counts from `ManagementClient`