### PR TITLE
Fix: Connection Limit Invalid for Queue/Topic Limits Greater than 100

### DIFF
--- a/PurpleExplorer/Helpers/BaseHelper.cs
+++ b/PurpleExplorer/Helpers/BaseHelper.cs
@@ -9,6 +9,8 @@ namespace PurpleExplorer.Helpers;
 
 public abstract class BaseHelper
 {
+    protected const int MaxRequestItemsPerPage = 100;
+
     protected ManagementClient GetManagementClient(ServiceBusConnectionString connectionString)
     {
         if (connectionString.UseManagedIdentity)

--- a/PurpleExplorer/Helpers/ITopicHelper.cs
+++ b/PurpleExplorer/Helpers/ITopicHelper.cs
@@ -10,9 +10,6 @@ public interface ITopicHelper
 {
     public Task<NamespaceInfo> GetNamespaceInfo(ServiceBusConnectionString connectionString);
     public Task<IList<ServiceBusTopic>> GetTopicsAndSubscriptions(ServiceBusConnectionString connectionString);
-    public Task<ServiceBusTopic> GetTopic(ServiceBusConnectionString connectionString, string topicPath, bool retrieveSubscriptions);
-    public Task<IList<ServiceBusSubscription>> GetSubscriptions(ServiceBusConnectionString connectionString, string topicPath);
-    public Task<ServiceBusSubscription> GetSubscription(ServiceBusConnectionString connectionString, string topicPath, string subscriptionName);
     public Task<IList<Message>> GetDlqMessages(ServiceBusConnectionString connectionString, string topic, string subscription);
     public Task<IList<Models.Message>> GetMessagesBySubscription(ServiceBusConnectionString connectionString, string topicName, string subscriptionName);
     public Task SendMessage(ServiceBusConnectionString connectionString, string topicPath, string content);

--- a/PurpleExplorer/Helpers/QueueHelper.cs
+++ b/PurpleExplorer/Helpers/QueueHelper.cs
@@ -14,8 +14,6 @@ namespace PurpleExplorer.Helpers;
 
 public class QueueHelper : BaseHelper, IQueueHelper
 {
-    private const int MaxQueueListFetchCountPerPage = 100;
-
     private readonly AppSettings _appSettings;
 
     public QueueHelper(AppSettings appSettings)
@@ -196,13 +194,13 @@ public class QueueHelper : BaseHelper, IQueueHelper
     private async Task<List<ServiceBusQueue>> GetQueues(ManagementClient client)
     {
         var queueInfos = new List<QueueRuntimeInfo>();
-        var numberOfPages = _appSettings.QueueListFetchCount / MaxQueueListFetchCountPerPage;
-        var remainder = _appSettings.QueueListFetchCount % (numberOfPages * MaxQueueListFetchCountPerPage);
+        var numberOfPages = _appSettings.QueueListFetchCount / MaxRequestItemsPerPage;
+        var remainder = _appSettings.QueueListFetchCount % (numberOfPages * MaxRequestItemsPerPage);
 
         for (int pageCount = 0; pageCount < numberOfPages; pageCount++)
         {
-            var numberToSkip = MaxQueueListFetchCountPerPage * pageCount;
-            var page = await client.GetQueuesRuntimeInfoAsync(MaxQueueListFetchCountPerPage, numberToSkip);
+            var numberToSkip = MaxRequestItemsPerPage * pageCount;
+            var page = await client.GetQueuesRuntimeInfoAsync(MaxRequestItemsPerPage, numberToSkip);
             if (page.Any())
             {
                 queueInfos.AddRange(page);
@@ -220,7 +218,7 @@ public class QueueHelper : BaseHelper, IQueueHelper
         if (remainder > 0)
         {
             var numberAlreadyFetched = numberOfPages > 0
-                ? MaxQueueListFetchCountPerPage * numberOfPages
+                ? MaxRequestItemsPerPage * numberOfPages
                 : 0;
             var remainingItems = await client.GetQueuesRuntimeInfoAsync(
                 remainder,

--- a/PurpleExplorer/Helpers/QueueHelper.cs
+++ b/PurpleExplorer/Helpers/QueueHelper.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Azure.ServiceBus.Management;
 using PurpleExplorer.Models;
 using Message = PurpleExplorer.Models.Message;
 using AzureMessage = Microsoft.Azure.ServiceBus.Message;
@@ -13,6 +14,8 @@ namespace PurpleExplorer.Helpers;
 
 public class QueueHelper : BaseHelper, IQueueHelper
 {
+    private const int MaxQueueListFetchCountPerPage = 100;
+
     private readonly AppSettings _appSettings;
 
     public QueueHelper(AppSettings appSettings)
@@ -22,29 +25,15 @@ public class QueueHelper : BaseHelper, IQueueHelper
 
     public async Task<IList<ServiceBusQueue>> GetQueues(ServiceBusConnectionString connectionString)
     {
-        IList<ServiceBusQueue> queues = new List<ServiceBusQueue>();
         var client = GetManagementClient(connectionString);
-        var queuesInfo = await client.GetQueuesRuntimeInfoAsync(_appSettings.QueueListFetchCount);
-        await client.CloseAsync();   
-            
-        await Task.WhenAll(queuesInfo.Select(async queue =>
-        {
-            var queueName = queue.Path;
-
-            var newQueue = new ServiceBusQueue(queue)
-            {
-                Name = queueName
-            };
-
-            queues.Add(newQueue);
-        }));
-
+        var queues = await GetQueues(client);
+        await client.CloseAsync();
         return queues;
     }
-        
+
     public async Task SendMessage(ServiceBusConnectionString connectionString, string queueName, string content)
     {
-        var message = new AzureMessage {Body = Encoding.UTF8.GetBytes(content)};
+        var message = new AzureMessage { Body = Encoding.UTF8.GetBytes(content) };
         await SendMessage(connectionString, queueName, message);
     }
 
@@ -72,7 +61,7 @@ public class QueueHelper : BaseHelper, IQueueHelper
 
         return receivedMessages.Select(message => new Message(message, true)).ToList();
     }
-        
+
     public async Task DeadletterMessage(ServiceBusConnectionString connectionString, string queue, Message message)
     {
         var receiver = GetMessageReceiver(connectionString, queue, ReceiveMode.PeekLock);
@@ -95,7 +84,7 @@ public class QueueHelper : BaseHelper, IQueueHelper
 
         await receiver.CloseAsync();
     }
-        
+
     public async Task DeleteMessage(ServiceBusConnectionString connectionString, string queue,
         Message message, bool isDlq)
     {
@@ -121,18 +110,19 @@ public class QueueHelper : BaseHelper, IQueueHelper
 
         await receiver.CloseAsync();
     }
-        
-    private async Task<AzureMessage> PeekDlqMessageBySequenceNumber(ServiceBusConnectionString connectionString, string queue, long sequenceNumber)
+
+    private async Task<AzureMessage> PeekDlqMessageBySequenceNumber(ServiceBusConnectionString connectionString,
+        string queue, long sequenceNumber)
     {
         var deadletterPath = EntityNameHelper.FormatDeadLetterPath(queue);
 
         var receiver = GetMessageReceiver(connectionString, deadletterPath, ReceiveMode.PeekLock);
         var azureMessage = await receiver.PeekBySequenceNumberAsync(sequenceNumber);
         await receiver.CloseAsync();
-            
+
         return azureMessage;
     }
-        
+
     public async Task ResubmitDlqMessage(ServiceBusConnectionString connectionString, string queue, Message message)
     {
         var azureMessage = await PeekDlqMessageBySequenceNumber(connectionString, queue, message.SequenceNumber);
@@ -165,7 +155,7 @@ public class QueueHelper : BaseHelper, IQueueHelper
         await receiver.CloseAsync();
         return purgedCount;
     }
-        
+
     public async Task<long> TransferDlqMessages(ServiceBusConnectionString connectionString, string queuePath)
     {
         var path = EntityNameHelper.FormatDeadLetterPath(queuePath);
@@ -193,7 +183,7 @@ public class QueueHelper : BaseHelper, IQueueHelper
         }
         finally
         {
-            if (receiver != null) 
+            if (receiver != null)
                 await receiver.CloseAsync();
 
             if (sender != null)
@@ -201,5 +191,46 @@ public class QueueHelper : BaseHelper, IQueueHelper
         }
 
         return transferredCount;
+    }
+    
+    private async Task<List<ServiceBusQueue>> GetQueues(ManagementClient client)
+    {
+        var queueInfos = new List<QueueRuntimeInfo>();
+        var numberOfPages = _appSettings.QueueListFetchCount / MaxQueueListFetchCountPerPage;
+        var remainder = _appSettings.QueueListFetchCount % (numberOfPages * MaxQueueListFetchCountPerPage);
+
+        for (int pageCount = 0; pageCount < numberOfPages; pageCount++)
+        {
+            var numberToSkip = MaxQueueListFetchCountPerPage * pageCount;
+            var page = await client.GetQueuesRuntimeInfoAsync(MaxQueueListFetchCountPerPage, numberToSkip);
+            if (page.Any())
+            {
+                queueInfos.AddRange(page);
+            }
+            else
+            {
+                return queueInfos
+                    .Select(q => new ServiceBusQueue(q)
+                    {
+                        Name = q.Path
+                    }).ToList();
+            }
+        }
+
+        if (remainder > 0)
+        {
+            var numberAlreadyFetched = numberOfPages > 0
+                ? MaxQueueListFetchCountPerPage * numberOfPages
+                : 0;
+            var remainingItems = await client.GetQueuesRuntimeInfoAsync(
+                remainder,
+                numberAlreadyFetched);
+            queueInfos.AddRange(remainingItems);
+        }
+
+        return queueInfos.Select(q => new ServiceBusQueue(q)
+        {
+            Name = q.Path
+        }).ToList();
     }
 }

--- a/PurpleExplorer/Helpers/TopicHelper.cs
+++ b/PurpleExplorer/Helpers/TopicHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AvaloniaEdit.Utils;
 using Message = PurpleExplorer.Models.Message;
 using AzureMessage = Microsoft.Azure.ServiceBus.Message;
 
@@ -14,6 +15,7 @@ namespace PurpleExplorer.Helpers;
 
 public class TopicHelper : BaseHelper, ITopicHelper
 {
+    private const int MaxTopicListFetchCountPerPage = 100;
     private readonly AppSettings _appSettings;
 
     public TopicHelper(AppSettings appSettings)
@@ -23,41 +25,76 @@ public class TopicHelper : BaseHelper, ITopicHelper
 
     public async Task<IList<ServiceBusTopic>> GetTopicsAndSubscriptions(ServiceBusConnectionString connectionString)
     {
-        IList<ServiceBusTopic> topics = new List<ServiceBusTopic>();
         var client = GetManagementClient(connectionString);
-        var busTopics = await client.GetTopicsAsync(_appSettings.TopicListFetchCount);
+        var topics = await GetTopicsWithSubscriptions(client);
         await client.CloseAsync();
-
-        await Task.WhenAll(busTopics.Select(async topic =>
-        {
-            var newTopic = new ServiceBusTopic(topic);
-
-            var subscriptions = await GetSubscriptions(connectionString, newTopic.Name);
-            newTopic.AddSubscriptions(subscriptions.ToArray());
-            topics.Add(newTopic);
-        }));
-
         return topics;
     }
 
-    public async Task<ServiceBusTopic> GetTopic(ServiceBusConnectionString connectionString, string topicPath, bool retrieveSubscriptions)
+    private async Task<ServiceBusTopic> CreateTopicWithSubscriptions(ManagementClient client, TopicDescription topicDescription)
+    {
+        var topic = new ServiceBusTopic(topicDescription);
+        var subscriptions = await GetSubscriptions(client, topicDescription.Path);
+        topic.AddSubscriptions(subscriptions.ToArray());
+        return topic;
+    }
+
+    private async Task<List<ServiceBusTopic>> GetTopicsWithSubscriptions(ManagementClient client)
+    {
+        var topicDescriptions = new List<TopicDescription>();
+        var numberOfPages = _appSettings.TopicListFetchCount / MaxTopicListFetchCountPerPage;
+        var remainder = _appSettings.TopicListFetchCount % (numberOfPages * MaxTopicListFetchCountPerPage);
+
+        for (int pageCount = 0; pageCount < numberOfPages; pageCount++)
+        {
+            var numberToSkip = MaxTopicListFetchCountPerPage * pageCount;
+            var page = await client.GetTopicsAsync(MaxTopicListFetchCountPerPage, numberToSkip);
+            if (page.Any())
+            {
+                topicDescriptions.AddRange(page);
+            }
+            else
+            {
+                return (await Task.WhenAll(topicDescriptions
+                    .Select(async topic => await CreateTopicWithSubscriptions(client, topic)))).ToList();
+            }
+        }
+
+        if (remainder > 0)
+        {
+            var numberAlreadyFetched = numberOfPages > 0
+                ? MaxTopicListFetchCountPerPage * numberOfPages
+                : 0;
+            var remainingItems = await client.GetTopicsAsync(
+                remainder,
+                numberAlreadyFetched);
+            topicDescriptions.AddRange(remainingItems);
+        }
+
+        var topics = await Task.WhenAll(topicDescriptions
+            .Select(async topic => await CreateTopicWithSubscriptions(client, topic)));
+        return topics.ToList();
+    }
+
+    public async Task<ServiceBusTopic> GetTopic(ServiceBusConnectionString connectionString, string topicPath,
+        bool retrieveSubscriptions)
     {
         var client = GetManagementClient(connectionString);
         var busTopics = await client.GetTopicAsync(topicPath);
-        await client.CloseAsync();
-
         var newTopic = new ServiceBusTopic(busTopics);
 
         if (retrieveSubscriptions)
         {
-            var subscriptions = await GetSubscriptions(connectionString, newTopic.Name);
+            var subscriptions = await GetSubscriptions(client, newTopic.Name);
             newTopic.AddSubscriptions(subscriptions.ToArray());
         }
-
+        
+        await client.CloseAsync();
         return newTopic;
     }
-        
-    public async Task<ServiceBusSubscription> GetSubscription(ServiceBusConnectionString connectionString, string topicPath, string subscriptionName)
+
+    public async Task<ServiceBusSubscription> GetSubscription(ServiceBusConnectionString connectionString,
+        string topicPath, string subscriptionName)
     {
         var client = GetManagementClient(connectionString);
         var runtimeInfo = await client.GetSubscriptionRuntimeInfoAsync(topicPath, subscriptionName);
@@ -66,12 +103,12 @@ public class TopicHelper : BaseHelper, ITopicHelper
         return new ServiceBusSubscription(runtimeInfo);
     }
 
-    public async Task<IList<ServiceBusSubscription>> GetSubscriptions(ServiceBusConnectionString connectionString, string topicPath)
+    private async Task<IList<ServiceBusSubscription>> GetSubscriptions(
+        ManagementClient client,
+        string topicPath)
     {
         IList<ServiceBusSubscription> subscriptions = new List<ServiceBusSubscription>();
-        var client = GetManagementClient(connectionString);
         var topicSubscription = await client.GetSubscriptionsRuntimeInfoAsync(topicPath);
-        await client.CloseAsync();
 
         foreach (var sub in topicSubscription)
         {
@@ -81,7 +118,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         return subscriptions;
     }
 
-    public async Task<IList<Message>> GetMessagesBySubscription(ServiceBusConnectionString connectionString, string topicName,
+    public async Task<IList<Message>> GetMessagesBySubscription(ServiceBusConnectionString connectionString,
+        string topicName,
         string subscriptionName)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicName, subscriptionName);
@@ -94,7 +132,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         return result;
     }
 
-    public async Task<IList<Message>> GetDlqMessages(ServiceBusConnectionString connectionString, string topic, string subscription)
+    public async Task<IList<Message>> GetDlqMessages(ServiceBusConnectionString connectionString, string topic,
+        string subscription)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topic, subscription);
         var deadletterPath = EntityNameHelper.FormatDeadLetterPath(path);
@@ -115,7 +154,7 @@ public class TopicHelper : BaseHelper, ITopicHelper
 
     public async Task SendMessage(ServiceBusConnectionString connectionString, string topicPath, string content)
     {
-        var message = new AzureMessage {Body = Encoding.UTF8.GetBytes(content)};
+        var message = new AzureMessage { Body = Encoding.UTF8.GetBytes(content) };
         await SendMessage(connectionString, topicPath, message);
     }
 
@@ -126,7 +165,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         await topicClient.CloseAsync();
     }
 
-    public async Task DeleteMessage(ServiceBusConnectionString connectionString, string topicPath, string subscriptionPath,
+    public async Task DeleteMessage(ServiceBusConnectionString connectionString, string topicPath,
+        string subscriptionPath,
         Message message, bool isDlq)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicPath, subscriptionPath);
@@ -153,7 +193,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         await receiver.CloseAsync();
     }
 
-    public async Task<long> PurgeMessages(ServiceBusConnectionString connectionString, string topicPath, string subscriptionPath,
+    public async Task<long> PurgeMessages(ServiceBusConnectionString connectionString, string topicPath,
+        string subscriptionPath,
         bool isDlq)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicPath, subscriptionPath);
@@ -177,11 +218,12 @@ public class TopicHelper : BaseHelper, ITopicHelper
         return purgedCount;
     }
 
-    public async Task<long> TransferDlqMessages(ServiceBusConnectionString connectionString, string topicPath, string subscriptionPath)
+    public async Task<long> TransferDlqMessages(ServiceBusConnectionString connectionString, string topicPath,
+        string subscriptionPath)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicPath, subscriptionPath);
         path = EntityNameHelper.FormatDeadLetterPath(path);
-            
+
         long transferredCount = 0;
         MessageReceiver receiver = null;
         TopicClient sender = null;
@@ -205,7 +247,7 @@ public class TopicHelper : BaseHelper, ITopicHelper
         }
         finally
         {
-            if (receiver != null) 
+            if (receiver != null)
                 await receiver.CloseAsync();
 
             if (sender != null)
@@ -215,7 +257,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         return transferredCount;
     }
 
-    private async Task<AzureMessage> PeekDlqMessageBySequenceNumber(ServiceBusConnectionString connectionString, string topicPath,
+    private async Task<AzureMessage> PeekDlqMessageBySequenceNumber(ServiceBusConnectionString connectionString,
+        string topicPath,
         string subscriptionPath, long sequenceNumber)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicPath, subscriptionPath);
@@ -224,11 +267,12 @@ public class TopicHelper : BaseHelper, ITopicHelper
         var receiver = GetMessageReceiver(connectionString, deadletterPath, ReceiveMode.PeekLock);
         var azureMessage = await receiver.PeekBySequenceNumberAsync(sequenceNumber);
         await receiver.CloseAsync();
-            
+
         return azureMessage;
     }
 
-    public async Task ResubmitDlqMessage(ServiceBusConnectionString connectionString, string topicPath, string subscriptionPath,
+    public async Task ResubmitDlqMessage(ServiceBusConnectionString connectionString, string topicPath,
+        string subscriptionPath,
         Message message)
     {
         var azureMessage = await PeekDlqMessageBySequenceNumber(connectionString, topicPath, subscriptionPath,
@@ -240,7 +284,8 @@ public class TopicHelper : BaseHelper, ITopicHelper
         await DeleteMessage(connectionString, topicPath, subscriptionPath, message, true);
     }
 
-    public async Task DeadletterMessage(ServiceBusConnectionString connectionString, string topicPath, string subscriptionPath,
+    public async Task DeadletterMessage(ServiceBusConnectionString connectionString, string topicPath,
+        string subscriptionPath,
         Message message)
     {
         var path = EntityNameHelper.FormatSubscriptionPath(topicPath, subscriptionPath);

--- a/PurpleExplorer/Helpers/TopicHelper.cs
+++ b/PurpleExplorer/Helpers/TopicHelper.cs
@@ -15,7 +15,6 @@ namespace PurpleExplorer.Helpers;
 
 public class TopicHelper : BaseHelper, ITopicHelper
 {
-    private const int MaxTopicListFetchCountPerPage = 100;
     private readonly AppSettings _appSettings;
 
     public TopicHelper(AppSettings appSettings)
@@ -42,13 +41,13 @@ public class TopicHelper : BaseHelper, ITopicHelper
     private async Task<List<ServiceBusTopic>> GetTopicsWithSubscriptions(ManagementClient client)
     {
         var topicDescriptions = new List<TopicDescription>();
-        var numberOfPages = _appSettings.TopicListFetchCount / MaxTopicListFetchCountPerPage;
-        var remainder = _appSettings.TopicListFetchCount % (numberOfPages * MaxTopicListFetchCountPerPage);
+        var numberOfPages = _appSettings.TopicListFetchCount / MaxRequestItemsPerPage;
+        var remainder = _appSettings.TopicListFetchCount % (numberOfPages * MaxRequestItemsPerPage);
 
         for (int pageCount = 0; pageCount < numberOfPages; pageCount++)
         {
-            var numberToSkip = MaxTopicListFetchCountPerPage * pageCount;
-            var page = await client.GetTopicsAsync(MaxTopicListFetchCountPerPage, numberToSkip);
+            var numberToSkip = MaxRequestItemsPerPage * pageCount;
+            var page = await client.GetTopicsAsync(MaxRequestItemsPerPage, numberToSkip);
             if (page.Any())
             {
                 topicDescriptions.AddRange(page);
@@ -63,7 +62,7 @@ public class TopicHelper : BaseHelper, ITopicHelper
         if (remainder > 0)
         {
             var numberAlreadyFetched = numberOfPages > 0
-                ? MaxTopicListFetchCountPerPage * numberOfPages
+                ? MaxRequestItemsPerPage * numberOfPages
                 : 0;
             var remainingItems = await client.GetTopicsAsync(
                 remainder,


### PR DESCRIPTION
Fixes Issue #63 

Queues and topic helpers now use paginated approach for querying.

Chore:
 - Removed unused interface method
 - Reused ManagementClient for populating topic subscriptions for more efficient use of connections
 
 Notes:
 
I didn't want to make wide sweeping changes and just focused on fixing the reported issue. 

Ideally, I'd like to split up the helper classes into SRP services and create a generic batching function for querying paginated methods like the get topic and queue methods.