### PR TITLE
Uses a resizable panel for Topics/Queue

### DIFF
--- a/PurpleExplorer/Views/MainWindow.xaml
+++ b/PurpleExplorer/Views/MainWindow.xaml
@@ -82,7 +82,7 @@
         </DockPanel>
 
         <DockPanel Grid.Column="0" Grid.Row="1" Dock="Left">
-			<Grid ColumnDefinitions="300, 5, *">
+            <Grid ColumnDefinitions="300, 5, *">
             <TabControl Grid.Column="0">
                 <TabItem Header="{Binding TopicTabHeader}">
                     <TreeView SelectionChanged="TreeView_SelectionChanged" Items="{Binding ConnectedServiceBuses}" Name="tvTopics">
@@ -122,7 +122,7 @@
                         </TreeView.Styles>
                     </TreeView>
                 </TabItem>
-				<TabItem Header="{Binding QueueTabHeader}">
+                <TabItem Header="{Binding QueueTabHeader}">
                     <TreeView SelectionChanged="TreeView_SelectionChanged" Items="{Binding ConnectedServiceBuses}" Name="tvQueues">
                         <TreeView.DataTemplates>
                             <TreeDataTemplate DataType="models:ServiceBusResource" ItemsSource="{Binding Queues}">
@@ -156,9 +156,9 @@
                 </TabItem>
             </TabControl>
 
-			<GridSplitter Grid.Column="1" ResizeBehavior="PreviousAndNext" VerticalAlignment="Stretch" Width="4" />
-			<!--GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" /-->
-			<TabControl Grid.Column="2">
+            <GridSplitter Grid.Column="1" ResizeBehavior="PreviousAndNext" VerticalAlignment="Stretch" Width="4" />
+
+            <TabControl Grid.Column="2">
                 <TabItem Header="{Binding MessagesTabHeader}" VerticalContentAlignment="Center">
                     <DataGrid Items="{Binding Messages}" Tapped="MessagesGrid_Tapped"
                               DoubleTapped="MessagesGrid_DoubleTapped"
@@ -190,7 +190,7 @@
                         </DataGrid>
                     </TabItem>
                 </TabControl>
-			</Grid>
+            </Grid>
         </DockPanel>
 
         <DockPanel Grid.Column="0" Grid.Row="2" Dock="Bottom">

--- a/PurpleExplorer/Views/MainWindow.xaml
+++ b/PurpleExplorer/Views/MainWindow.xaml
@@ -82,7 +82,8 @@
         </DockPanel>
 
         <DockPanel Grid.Column="0" Grid.Row="1" Dock="Left">
-            <TabControl Width="300">
+			<Grid ColumnDefinitions="300, 5, *">
+            <TabControl Grid.Column="0">
                 <TabItem Header="{Binding TopicTabHeader}">
                     <TreeView SelectionChanged="TreeView_SelectionChanged" Items="{Binding ConnectedServiceBuses}" Name="tvTopics">
                         <TreeView.DataTemplates>
@@ -121,7 +122,7 @@
                         </TreeView.Styles>
                     </TreeView>
                 </TabItem>
-                <TabItem Header="{Binding QueueTabHeader}">
+				<TabItem Header="{Binding QueueTabHeader}">
                     <TreeView SelectionChanged="TreeView_SelectionChanged" Items="{Binding ConnectedServiceBuses}" Name="tvQueues">
                         <TreeView.DataTemplates>
                             <TreeDataTemplate DataType="models:ServiceBusResource" ItemsSource="{Binding Queues}">
@@ -155,7 +156,9 @@
                 </TabItem>
             </TabControl>
 
-            <TabControl>
+			<GridSplitter Grid.Column="1" ResizeBehavior="PreviousAndNext" VerticalAlignment="Stretch" Width="4" />
+			<!--GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" /-->
+			<TabControl Grid.Column="2">
                 <TabItem Header="{Binding MessagesTabHeader}" VerticalContentAlignment="Center">
                     <DataGrid Items="{Binding Messages}" Tapped="MessagesGrid_Tapped"
                               DoubleTapped="MessagesGrid_DoubleTapped"
@@ -187,6 +190,7 @@
                         </DataGrid>
                     </TabItem>
                 </TabControl>
+			</Grid>
         </DockPanel>
 
         <DockPanel Grid.Column="0" Grid.Row="2" Dock="Bottom">


### PR DESCRIPTION
The Topic/Queues left panel is occasionally too narrow to display the whole names and the scrolling is cumbersome:
![image](https://github.com/telstrapurple/PurpleExplorer/assets/709928/48680458-bd0e-436d-b09f-b4f958b8323f)

This fix enables a splitter between the Topics/Queues panels and the Messages panels.
![image](https://github.com/telstrapurple/PurpleExplorer/assets/709928/dbb8f435-d61e-4118-aaa1-ead6e05ac1e5)

