### PR TITLE
When deleting messages, match by message id and seq no.

### DIFF
--- a/PurpleExplorer/Models/MessageCollection.cs
+++ b/PurpleExplorer/Models/MessageCollection.cs
@@ -48,12 +48,13 @@ public abstract class MessageCollection : ReactiveObject
         MessageCount = Messages.Count;
     }
 
-    public void RemoveMessage(string messageId)
+    public void RemoveMessage(string messageId, long seqNo)
     {
-        Messages.Remove(Messages.Single(msg => msg.MessageId.Equals(messageId)));
+        var match = (Message msg) => msg.MessageId.Equals(messageId) && msg.SequenceNumber.Equals(seqNo);
+        Messages.Remove(Messages.Single(match));
         MessageCount = Messages.Count;
     }
-        
+    
     public void ClearMessages()
     {
         Messages.Clear();
@@ -66,9 +67,10 @@ public abstract class MessageCollection : ReactiveObject
         DlqCount = DlqMessages.Count;
     }
         
-    public void RemoveDlqMessage(string messageId)
+    public void RemoveDlqMessage(string messageId, long seqNo)
     {
-        DlqMessages.Remove(DlqMessages.Single(msg => msg.MessageId.Equals(messageId)));
+        var match = (Message msg) => msg.MessageId.Equals(messageId) && msg.SequenceNumber.Equals(seqNo);
+        DlqMessages.Remove(DlqMessages.Single(match));
         DlqCount = DlqMessages.Count;
     }
         

--- a/PurpleExplorer/ViewModels/MessageDetailsWindowViewModel.cs
+++ b/PurpleExplorer/ViewModels/MessageDetailsWindowViewModel.cs
@@ -69,9 +69,9 @@ public class MessageDetailsWindowViewModel : ViewModelBase
                 Message, Message.IsDlq);
                 
             if(!Message.IsDlq) 
-                Subscription.RemoveMessage(Message.MessageId);
+                Subscription.RemoveMessage(Message.MessageId, Message.SequenceNumber);
             else
-                Subscription.RemoveDlqMessage(Message.MessageId);
+                Subscription.RemoveDlqMessage(Message.MessageId, Message.SequenceNumber);
         }
 
         if (Queue != null)
@@ -80,9 +80,9 @@ public class MessageDetailsWindowViewModel : ViewModelBase
             await _queueHelper.DeleteMessage(connectionString, Queue.Name, Message, Message.IsDlq);
                 
             if(!Message.IsDlq) 
-                Queue.RemoveMessage(Message.MessageId);
+                Queue.RemoveMessage(Message.MessageId, Message.SequenceNumber);
             else
-                Queue.RemoveDlqMessage(Message.MessageId);
+                Queue.RemoveDlqMessage(Message.MessageId, Message.SequenceNumber);
         }
 
         _loggingService.Log($"Message deleted, MessageId: {Message.MessageId}");


### PR DESCRIPTION
It is possible that service bus messages will share a message id. This was causing issues when deleting messages as it called `.Single(pred)` yet there were multiple matching messages. This PR matches on message id and sequence number when deleting messages instead.

```
System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at PurpleExplorer.Models.MessageCollection.RemoveMessage(String messageId) in /home/ae/src/ext/PurpleExplorer/PurpleExplorer/Models/MessageCollection.cs:line 53
   at PurpleExplorer.ViewModels.MessageDetailsWindowViewModel.DeleteMessage(Window window) in /home/ae/src/ext/PurpleExplorer/PurpleExplorer/ViewModels/MessageDetailsWindowViewModel.cs:line 83
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   at Avalonia.Threading.AvaloniaSynchronizationContext.<>c__DisplayClass5_0.<Post>b__0() in /_/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs:line 33
   at Avalonia.Threading.JobRunner.Job.Avalonia.Threading.JobRunner.IJob.Run() in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 181
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
   at Avalonia.X11.X11PlatformThreading.CheckSignaled() in /_/src/Avalonia.X11/X11PlatformThreading.cs:line 164
   at Avalonia.X11.X11PlatformThreading.RunLoop(CancellationToken cancellationToken) in /_/src/Avalonia.X11/X11PlatformThreading.cs:line 244
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
   at PurpleExplorer.Program.Main(String[] args) in /home/ae/src/ext/PurpleExplorer/PurpleExplorer/Program.cs:line 13
```