### PR TITLE
Issue: Enter key doesn't work to get to new line while adding messages for queue (Windows)

### DIFF
--- a/PurpleExplorer/Views/AddMessageWindow.xaml
+++ b/PurpleExplorer/Views/AddMessageWindow.xaml
@@ -23,7 +23,8 @@
 
         <TextBox MinHeight="180" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                  FontFamily="Microsoft YaHei,Simsun,苹方-简,宋体-简"
-                 TextWrapping="Wrap" Text="{Binding Path=Message, Mode=TwoWay}" />
+                 TextWrapping="Wrap" Text="{Binding Path=Message, Mode=TwoWay}"
+                 AcceptsReturn="True" />
 
         <StackPanel Grid.Row="1" Margin="0,5,0,5" Orientation="Horizontal" HorizontalAlignment="Stretch">
             <Button MinWidth="200" Height="30" HorizontalAlignment="Stretch" VerticalAlignment="Center"


### PR DESCRIPTION
Fix the issue where enter key was not working in the Add message textbox for queues